### PR TITLE
Simplify latest repos query to use first/DESC ordering

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,10 +42,10 @@ if (GITHUB_TOKEN) {
         }
       }
       repositories(
-        last: 5
+        first: 5
         isFork: false
         affiliations: OWNER
-        orderBy: { field: PUSHED_AT, direction: ASC }
+        orderBy: { field: PUSHED_AT, direction: DESC }
       ) {
         nodes {
           name
@@ -73,7 +73,7 @@ if (GITHUB_TOKEN) {
 
   const { data } = await res.json()
   pinnedRepos = data.viewer.pinnedItems.nodes
-  latestRepos = [...data.viewer.repositories.nodes].reverse()
+  latestRepos = data.viewer.repositories.nodes
 }
 ---
 


### PR DESCRIPTION
## Summary

- Replace `last: 5` + `ASC` ordering + JS `.reverse()` in `src/pages/index.astro` with `first: 5` + `DESC` ordering directly in the GraphQL query
- Functionally equivalent: both produce the 5 most recently pushed repos in newest-first order
- Removes the now-unneeded `.reverse()` call

## Context

Investigating why the "Open source works" and "Latest hacks" sections disappeared from the homepage after the Gatsby → Astro migration. Root cause is that `GITHUB_TOKEN` is not set in the Cloudflare Workers Builds environment, so the build-time GraphQL fetch in `index.astro` is skipped and the repo arrays stay empty. Fix for the missing sections is to add `GITHUB_TOKEN` under **Settings → Builds → Build variables and secrets** in the Cloudflare dashboard (no code change).

This PR is a small unrelated cleanup noticed during that investigation.

## Test plan

- [ ] Set `GITHUB_TOKEN` build secret in Cloudflare dashboard
- [ ] Trigger a build and confirm both repo sections render on the homepage
- [ ] Confirm "Latest hacks" lists the 5 most recently pushed repos, newest first

https://claude.ai/code/session_0169pubt9Kiw2EA9sGt8YwKR

---
_Generated by [Claude Code](https://claude.ai/code/session_0169pubt9Kiw2EA9sGt8YwKR)_