### PR TITLE
Remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "10:00"
-  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,25 +6,3 @@ updates:
     interval: monthly
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: gatsby-plugin-feed
-    versions:
-    - 2.10.0
-    - 2.12.0
-  - dependency-name: gatsby-remark-copy-linked-files
-    versions:
-    - 2.7.0
-    - 2.9.0
-  - dependency-name: gatsby-remark-smartypants
-    versions:
-    - 2.7.0
-    - 2.9.0
-  - dependency-name: gatsby-source-filesystem
-    versions:
-    - 2.8.1
-  - dependency-name: react
-    versions:
-    - 16.14.0
-  - dependency-name: bl
-    versions:
-    - 1.2.3


### PR DESCRIPTION
## Summary

- Deletes `.github/dependabot.yml` entirely. Dependencies will be upgraded manually instead of via automated Dependabot PRs.
- The previous config also contained stale `ignore` entries for Gatsby/React/bl packages that no longer exist in `package.json` (the site is on Astro now), so removing the file cleans that up as a side effect.

## Test plan

- [ ] Confirm Dependabot stops opening PRs on this repo after merge.

https://claude.ai/code/session_01XXGBrixVVwGNGxKpZT8gtq