### PR TITLE
Fix deploy hook secret name in GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Trigger deploy hook
         shell: bash
         env:
-          CLOUDFLARE_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}
-        run: curl -X POST "$CLOUDFLARE_DEPLOY_HOOK"
+          CF_DEPLOY_HOOK: ${{ secrets.CF_DEPLOY_HOOK }}
+        run: curl -X POST "$CF_DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- The repo secret is stored as `CF_DEPLOY_HOOK`, but `.github/workflows/main.yml` referenced `CLOUDFLARE_DEPLOY_HOOK`, so the curl in the scheduled job was POSTing to an empty URL and the action was failing.
- Renamed both the env var and the `secrets.*` reference to `CF_DEPLOY_HOOK`.

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm the curl receives a 2xx from the Cloudflare deploy hook.
- [ ] Confirm a Cloudflare Pages build is queued after the run.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MUEcEPXb46RpMZjaj8vmQ)_